### PR TITLE
docs: fix sections for imports order

### DIFF
--- a/chapter_1_pythonic_thinking_items_1-10/README.md
+++ b/chapter_1_pythonic_thinking_items_1-10/README.md
@@ -50,10 +50,9 @@ Find the one, and/or only one obvious way to do it.
 * ``from bar import foo`` always use absolute names
 * ``from . import foo`` for relative import
 * Section imports in the following order:
-    1. standard library
-    2. modules
-    3. 3rd-party modules
-    4. your own modules
+    1. standard library modules
+    2. 3rd-party modules
+    3. your own modules
 
 ## Item 3: Know the Differences Between ``bytes`` and ``str``
 


### PR DESCRIPTION
## Description

The changes above come from comparing the original book text with the repository code. I noticed an unnecessary split between `standard library` and `modules`, as they stand for the same point in the original.

## Screenshots:

<img width="736" alt="Screenshot 2024-11-16 at 02 39 59" src="https://github.com/user-attachments/assets/d6af609a-0ec2-4f48-990b-b148625c8895">